### PR TITLE
Add persistent browser session

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ still run.
 Each puppet has a "Close browser" checkbox in the sidebar. When enabled the
 browser will automatically close once all steps finish running.
 
+ProgramaticPuppet now reuses a single Puppeteer session so you remain logged in
+between runs. If you need to start over with a fresh session send a POST request
+to the `/resetBrowser` endpoint.
+
 <!--
 Each puppet also stores a **printifyProductURL** value. Set this URL in the text
 field above the loop options. The new `loadPrintifyProductURL` step uses this

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -134,3 +134,17 @@ paths:
                 properties:
                   error:
                     type: string
+  /resetBrowser:
+    post:
+      summary: Close and reset the persistent browser session
+      responses:
+        '200':
+          description: Browser instance closed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: closed


### PR DESCRIPTION
## Summary
- keep a persistent Puppeteer page to retain login state
- document new `/resetBrowser` endpoint
- allow resetting the persistent browser

## Testing
- `node --check index.js`
- `node --check test-call.js`
- `node --check public/script.js`


------
https://chatgpt.com/codex/tasks/task_b_685f5eaaca7c8323ac6108841c67befd