### PR TITLE
Add eBay EPS image upload step

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,14 @@ currently focused input field.
 
 The **keyPress** step presses the provided keyboard key. Key names are case-insensitive so `backspace` or `Backspace` both work.
 
-The **tabNTimes** step automatically presses the Tab key the specified number of
-times. Enter the repeat count in the second field of the UI. Each Tab press is
-followed by a 0.1 second pause.
+  The **tabNTimes** step automatically presses the Tab key the specified number of
+  times. Enter the repeat count in the second field of the UI. Each Tab press is
+  followed by a 0.1 second pause.
+
+The **ebayUploadImage** step uploads one or more images to the currently open eBay
+listing page. Provide a comma‑separated list of file paths and optionally an item
+ID. The step pulls the EPS endpoint and CSRF token from the page, fetches a fresh
+`SRT` token and then posts each image using `multipart/form-data`.
 
 The **end** step stops execution of the current puppet instance immediately,
 skipping any remaining steps. When loops are enabled, later iterations will

--- a/public/script.js
+++ b/public/script.js
@@ -25,6 +25,7 @@ const stepTypes = [
   'selectAllText',
   'keyPress',
   'tabNTimes',
+  'ebayUploadImage',
   'end'
 ];
 let dragSource = null;
@@ -189,6 +190,19 @@ function addFields(div, step = {}) {
     if (step.times) timesInput.value = step.times;
     timesInput.style.width = '60px';
     div.appendChild(timesInput);
+  } else if (step.type === 'ebayUploadImage') {
+    const pathsInput = document.createElement('input');
+    pathsInput.placeholder = 'image paths';
+    pathsInput.className = 'image-paths';
+    if (step.paths) pathsInput.value = step.paths;
+    div.appendChild(pathsInput);
+
+    const itemInput = document.createElement('input');
+    itemInput.placeholder = 'item id';
+    itemInput.className = 'image-item-id';
+    if (step.itemId) itemInput.value = step.itemId;
+    itemInput.style.width = '120px';
+    div.appendChild(itemInput);
   } else if (step.type === 'end' || step.type === 'scrollBottom' || step.type === 'selectAllText' || step.type === 'loadPrintifyProductURL') {
     // no additional fields
   } else {
@@ -297,6 +311,10 @@ function collectSteps() {
   } else if (type === 'tabNTimes') {
     const count = Number(div.querySelector('.tab-times')?.value || 1);
     result.push({ type, times: count });
+  } else if (type === 'ebayUploadImage') {
+    const paths = div.querySelector('.image-paths')?.value || '';
+    const itemId = div.querySelector('.image-item-id')?.value || '';
+    result.push({ type, paths, itemId });
   } else {
       const val = div.querySelector('input')?.value || '';
       if (type === 'loadURL') result.push({ type, url: val });


### PR DESCRIPTION
## Summary
- add new `ebayUploadImage` step type in browser UI
- implement server-side logic to read EPS config, fetch CSRF token and upload images
- document the new step in README

## Testing
- `npm test` *(fails: Missing script)*
- `node test-call.js` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_b_687025931adc8323b2993b13592e4537