### PR TITLE
Fix file upload fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,15 @@ async function runSteps(opts, logger = console.log) {
           .map(s => s.trim())
           .filter(Boolean);
         const selector = step.selector || 'input[type="file"]';
-        await page.setInputFiles(selector, imagePaths);
+        if (typeof page.setInputFiles === 'function') {
+          await page.setInputFiles(selector, imagePaths);
+        } else {
+          const handle = await page.$(selector);
+          if (!handle) {
+            throw new Error(`File input not found for selector: ${selector}`);
+          }
+          await handle.uploadFile(...imagePaths);
+        }
         logger(
           `[ProgramaticPuppet] Uploaded via UI: ${imagePaths.join(', ')}`,
         );


### PR DESCRIPTION
## Summary
- handle when older puppeteer API is missing `page.setInputFiles`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68703bd754bc8323ae802217a5a908f4