### PR TITLE
Add runtime variables and setVariable step

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,7 @@ is checked the browser will be relaunched between each loop.
 
 Use the **Rename Puppet** button in the sidebar to change the name of the
 currently selected puppet.
+
+The editor now includes a **Variables** panel for defining runtime variables.
+Each entry is a name/value pair that gets sent to the server when executing a
+puppet. The new **setVariable** step can modify these values during a run.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,6 +34,10 @@ paths:
                       minimum: 1
                     printifyProductURL:
                       type: string
+                    variables:
+                      type: object
+                      additionalProperties:
+                        type: string
               description: |
                 Either an array of step objects or an object with a `steps` array
                 and optional options.
@@ -97,6 +101,10 @@ paths:
                   type: integer
                   minimum: 1
                   description: Optional override for loop count
+                variables:
+                  type: object
+                  additionalProperties:
+                    type: string
       responses:
         '200':
           description: Stream of execution logs as Server-Sent Events

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,11 @@
   <div id="main">
     <div id="steps"></div>
     <button onclick="addStep()">Add Step</button>
+    <div id="variablesPanel" style="margin-top:8px;">
+      <strong>Variables</strong>
+      <div id="variablesList"></div>
+      <button onclick="addVariableField()">Add Variable</button>
+    </div>
     <div style="margin-top:8px;">
       <input type="text" id="printifyProductURL" placeholder="Printify Product URL" style="width:100%;" />
     </div>


### PR DESCRIPTION
## Summary
- add Variables panel UI
- allow saving/loading variables per puppet
- implement new `setVariable` step in client and server
- send variables to the backend and support variable interpolation
- document new variables feature and update API spec

## Testing
- `node --check index.js && node --check public/script.js`

------
https://chatgpt.com/codex/tasks/task_b_6871473f952483238d0fe6d8abb48261