### PR TITLE
Add ebayListingTitle step

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ The **keyPress** step presses the provided keyboard key. Key names are case-inse
   times. Enter the repeat count in the second field of the UI. Each Tab press is
   followed by a 0.1 second pause.
 
+The **ebayListingTitle** step sends an image to the GPT‑4o‑mini vision API to
+generate an eBay listing title. Provide the local file path to the image. The
+resulting title is stored in the `ebayTitle` variable. Set your OpenAI API key
+in the `OPENAI_API_KEY` environment variable before running this step.
+
 The **ebayUploadImage** step uploads one or more images to the currently open eBay
 listing page. Provide a comma‑separated list of file paths and optionally an item
 ID. The step pulls the EPS endpoint and CSRF token from the page, fetches a fresh

--- a/public/script.js
+++ b/public/script.js
@@ -26,6 +26,7 @@ const stepTypes = [
   'selectAllText',
   'keyPress',
   'tabNTimes',
+  'ebayListingTitle',
   'ebayUploadImage',
   'uiUploadFile',
   'setVariable',
@@ -229,6 +230,12 @@ function addFields(div, step = {}) {
     if (step.times) timesInput.value = step.times;
     timesInput.style.width = '60px';
     div.appendChild(timesInput);
+  } else if (step.type === 'ebayListingTitle') {
+    const imgInput = document.createElement('input');
+    imgInput.placeholder = 'image path';
+    imgInput.className = 'ebay-title-image';
+    if (step.image) imgInput.value = step.image;
+    div.appendChild(imgInput);
   } else if (step.type === 'ebayUploadImage') {
     const pathsInput = document.createElement('input');
     pathsInput.placeholder = 'image paths';
@@ -376,6 +383,9 @@ function collectSteps() {
   } else if (type === 'tabNTimes') {
     const count = Number(div.querySelector('.tab-times')?.value || 1);
     result.push({ type, times: count });
+  } else if (type === 'ebayListingTitle') {
+    const image = div.querySelector('.ebay-title-image')?.value || '';
+    result.push({ type, image });
   } else if (type === 'ebayUploadImage') {
     const paths = div.querySelector('.image-paths')?.value || '';
     const itemId = div.querySelector('.image-item-id')?.value || '';


### PR DESCRIPTION
## Summary
- add new step type `ebayListingTitle` in the editor
- call GPT‑4o‑mini vision API to create an eBay title from an image
- store the resulting title in `ebayTitle`
- document new step in README

## Testing
- `node --check index.js`
- `node --check public/script.js`

------
https://chatgpt.com/codex/tasks/task_b_68714e3ceb7c8323aff5e91584fa80f6