### PR TITLE
Add automatic ebayTitle variable creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ The **keyPress** step presses the provided keyboard key. Key names are case-inse
 
 The **ebayListingTitle** step sends an image to the GPT‑4o‑mini vision API to
 generate an eBay listing title. Provide the local file path to the image. The
-resulting title is stored in the `ebayTitle` variable. Set your OpenAI API key
-in the `OPENAI_API_KEY` environment variable before running this step.
+resulting title is stored in the `ebayTitle` variable. When this step is added
+to a puppet the editor now automatically creates an `ebayTitle` entry in the
+Variables panel if one is not already present. Set your OpenAI API key in the
+`OPENAI_API_KEY` environment variable before running this step.
 
 The **ebayUploadImage** step uploads one or more images to the currently open eBay
 listing page. Provide a comma‑separated list of file paths and optionally an item

--- a/public/script.js
+++ b/public/script.js
@@ -90,6 +90,15 @@ function addVariableField(name = '', value = '') {
   variablesList.appendChild(row);
 }
 
+function ensureEbayTitleVariable() {
+  const hasVar = Array.from(
+    variablesList.querySelectorAll('.var-row-name'),
+  ).some(input => input.value === 'ebayTitle');
+  if (!hasVar) {
+    addVariableField('ebayTitle', '');
+  }
+}
+
 function loadVariables(vars = {}) {
   variablesList.innerHTML = '';
   Object.keys(vars).forEach(k => addVariableField(k, vars[k]));
@@ -236,6 +245,7 @@ function addFields(div, step = {}) {
     imgInput.className = 'ebay-title-image';
     if (step.image) imgInput.value = step.image;
     div.appendChild(imgInput);
+    ensureEbayTitleVariable();
   } else if (step.type === 'ebayUploadImage') {
     const pathsInput = document.createElement('input');
     pathsInput.placeholder = 'image paths';
@@ -320,6 +330,9 @@ function addStep(step = {}) {
     // remove existing inputs
     Array.from(div.querySelectorAll('input')).forEach(el => el.remove());
     addFields(div, { type: select.value });
+    if (select.value === 'ebayListingTitle') {
+      ensureEbayTitleVariable();
+    }
   });
   div.appendChild(select);
   addFields(div, step);


### PR DESCRIPTION
## Summary
- auto-create `ebayTitle` variable when ebayListingTitle step is used
- mention this in README

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_687154e770988323b4816770a7ef7e8d