### PR TITLE
Handle clickText failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ the selector field was mistakenly used to hold the text value.
 Click steps also accept an optional second field specifying which step number to jump to when the element cannot be clicked. This allows basic fallback logic when selectors fail.
 
 The **clickText** step searches the current page for an element whose text
-contains the provided value and clicks it.
+contains the provided value and clicks it. If no match is found before the
+timeout elapses, the step logs the failure and the script continues to the next
+step rather than aborting.
 
 The **clickName** step clicks the first element with the given `name`
 attribute. Specify just the attribute value, for example `clear` will click the

--- a/index.js
+++ b/index.js
@@ -159,7 +159,11 @@ async function runSteps(opts, logger = console.log) {
           }
         }
       } else if (type === 'clickText') {
-        await clickText(step.text);
+        try {
+          await clickText(step.text);
+        } catch (err) {
+          logger(`[ProgramaticPuppet] clickText failed: ${err}`);
+        }
       } else if (type === 'clickTextCheckbox') {
         await clickTextCheckbox(step.text);
       } else if (type === 'clickName') {


### PR DESCRIPTION
## Summary
- let `clickText` failures fall through so the next step can run
- document new behavior in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: internet access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_687159addc5c8323a1d2d867ae561ad7