### PR TITLE
Strip quotes when typing variable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ The editor now includes a **Variables** panel for defining runtime variables.
 Each entry is a name/value pair that gets sent to the server when executing a
 puppet. The **setVariable** step can modify these values during a run and the
 new **typeVar** step types the value stored in the named variable into the
-currently focused field.
+currently focused field, automatically stripping any double quote (\") characters.

--- a/index.js
+++ b/index.js
@@ -349,7 +349,7 @@ async function runSteps(opts, logger = console.log) {
         }
       } else if (type === 'typeVar') {
         const name = step.name || '';
-        const textToType = String(variables[name] || '');
+        const textToType = String(variables[name] || '').replace(/"/g, '');
         const target = step.selector ? htmlToSelector(step.selector) : null;
         for (const ch of textToType) {
           if (target) {


### PR DESCRIPTION
## Summary
- strip `"` characters from values in `typeVar` step
- document the quote removal in README

## Testing
- `node index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_6871596f88b88323bb4f4b4c03b944ed