### PR TITLE
Add eBay price step

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ to a puppet the editor now automatically creates an `ebayTitle` entry in the
 Variables panel if one is not already present. Set your OpenAI API key in the
 `OPENAI_API_KEY` environment variable before running this step.
 
+The **ebayPrice** step sends the current `ebayTitle` value to the GPT‑4o-search-preview
+model and asks for a suggested eBay price. The prompt instructs the model to end
+its reply with a line formatted as `Ebay Suggested Price: $xx.xx` and to never
+suggest less than $10. The extracted dollar amount is stored in the `ebayPrice`
+variable. Adding this step automatically creates an `ebayPrice` entry in the
+Variables panel if needed.
+
 The **ebayUploadImage** step uploads one or more images to the currently open eBay
 listing page. Provide a comma‑separated list of file paths and optionally an item
 ID. The step pulls the EPS endpoint and CSRF token from the page, fetches a fresh

--- a/public/script.js
+++ b/public/script.js
@@ -28,6 +28,7 @@ const stepTypes = [
   'keyPress',
   'tabNTimes',
   'ebayListingTitle',
+  'ebayPrice',
   'ebayUploadImage',
   'uiUploadFile',
   'setVariable',
@@ -97,6 +98,15 @@ function ensureEbayTitleVariable() {
   ).some(input => input.value === 'ebayTitle');
   if (!hasVar) {
     addVariableField('ebayTitle', '');
+  }
+}
+
+function ensureEbayPriceVariable() {
+  const hasVar = Array.from(
+    variablesList.querySelectorAll('.var-row-name'),
+  ).some(input => input.value === 'ebayPrice');
+  if (!hasVar) {
+    addVariableField('ebayPrice', '');
   }
 }
 
@@ -247,6 +257,9 @@ function addFields(div, step = {}) {
     if (step.image) imgInput.value = step.image;
     div.appendChild(imgInput);
     ensureEbayTitleVariable();
+  } else if (step.type === 'ebayPrice') {
+    ensureEbayTitleVariable();
+    ensureEbayPriceVariable();
   } else if (step.type === 'ebayUploadImage') {
     const pathsInput = document.createElement('input');
     pathsInput.placeholder = 'image paths';
@@ -339,6 +352,9 @@ function addStep(step = {}) {
     addFields(div, { type: select.value });
     if (select.value === 'ebayListingTitle') {
       ensureEbayTitleVariable();
+    } else if (select.value === 'ebayPrice') {
+      ensureEbayTitleVariable();
+      ensureEbayPriceVariable();
     }
   });
   div.appendChild(select);
@@ -406,6 +422,8 @@ function collectSteps() {
   } else if (type === 'ebayListingTitle') {
     const image = div.querySelector('.ebay-title-image')?.value || '';
     result.push({ type, image });
+  } else if (type === 'ebayPrice') {
+    result.push({ type });
   } else if (type === 'ebayUploadImage') {
     const paths = div.querySelector('.image-paths')?.value || '';
     const itemId = div.querySelector('.image-item-id')?.value || '';


### PR DESCRIPTION
## Summary
- add new `ebayPrice` step for pricing suggestions
- support automatic `ebayPrice` variable creation in the editor
- query GPT‑4o-search-preview to get a suggested price
- update README with details about the new step

## Testing
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_b_6871664ecae48323b1c5c7f0227f8e79