### PR TITLE
Add runner menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Sample self-signed certificates `server.key` and `server.cert` are included for
 local HTTPS development.
 
 Open [https://localhost:3005](https://localhost:3005) in your browser and build a small script.  Press **Run Steps** to execute the flow with PuppetCore.
+You can also manage stored puppets using the runner page at
+[https://localhost:3005/runner.html](https://localhost:3005/runner.html).
+It allows queuing multiple puppets and passing in custom variables before each run.
 
 For **click** and **type** steps, provide a CSS selector for the target element.
 Type steps insert each character with a 0.5 s delay to better mimic human input.

--- a/index.js
+++ b/index.js
@@ -490,6 +490,9 @@ const PORT = process.env.PORT || 3005;
 
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, 'public')));
+app.get('/runner', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'runner.html'));
+});
 
 app.post('/run', async (req, res) => {
   let steps = [];

--- a/public/runner.html
+++ b/public/runner.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ProgramaticPuppet Runner</title>
+  <style>
+    body { font-family: sans-serif; max-width: 800px; margin: auto; }
+    #varsList div { margin-bottom: 4px; }
+    #queueList { margin-top: 8px; }
+    pre { white-space: pre-wrap; background:#f0f0f0; padding:8px; height:200px; overflow:auto; }
+  </style>
+</head>
+<body>
+<h1>ProgramaticPuppet Runner</h1>
+<div>
+  <label>Puppet:
+    <select id="puppetSelect"></select>
+  </label>
+</div>
+<div style="margin-top:8px;">
+  <input type="text" id="productURL" placeholder="Printify Product URL" style="width:100%;"/>
+</div>
+<div style="margin-top:8px;">
+  <label>Loops: <input type="number" id="loops" value="1" min="1" style="width:60px;"/></label>
+</div>
+<div id="varsPanel" style="margin-top:8px;">
+  <strong>Variables</strong>
+  <div id="varsList"></div>
+  <button onclick="addVar()">Add Variable</button>
+</div>
+<div style="margin-top:8px;">
+  <button onclick="runNow()">Run Now</button>
+  <button onclick="addToQueue()">Add To Queue</button>
+  <button onclick="startQueue()">Start Queue</button>
+</div>
+<h2>Queue</h2>
+<ul id="queueList"></ul>
+<h2>Logs</h2>
+<pre id="log"></pre>
+<script src="runner.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `runner.html` and `runner.js` for running stored puppets
- implement basic queue UI for sequential execution
- expose `/runner` route from the server
- document the new runner page in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6871c23c91c08323b6b92f79f54fd762