### PR TITLE
Handle quoted file paths in ProgramaticPuppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ name of a variable that contains the path. The resulting title is stored in the
 `ebayTitle` variable. When this step is added to a puppet the editor now
 automatically creates an `ebayTitle` entry in the Variables panel if one is not
 already present. Set your OpenAI API key in the `OPENAI_API_KEY` environment
-variable before running this step.
+variable before running this step. Paths surrounded by single or double quotes
+are handled automatically, so quoting the value in the Variables panel is safe.
 
 The **ebayPrice** step sends the current `ebayTitle` value to the GPT‑4o-search-preview
 model and asks for a suggested eBay price. The prompt instructs the model to end

--- a/index.js
+++ b/index.js
@@ -219,8 +219,11 @@ async function runSteps(opts, logger = console.log) {
           await sleep_helper(0.1);
         }
       } else if (type === 'ebayListingTitle') {
-        const imagePath =
+        const rawImagePath =
           (step.imageVar && variables[step.imageVar]) || step.image;
+        const imagePath = String(rawImagePath)
+          .trim()
+          .replace(/^['"]+|['"]+$/g, '');
         if (!process.env.OPENAI_API_KEY) {
           logger('[ProgramaticPuppet] OPENAI_API_KEY not set');
         } else if (imagePath && fs.existsSync(imagePath)) {
@@ -305,7 +308,7 @@ async function runSteps(opts, logger = console.log) {
       } else if (type === 'ebayUploadImage') {
         const imagePaths = String(step.paths || '')
           .split(',')
-          .map(s => s.trim())
+          .map(s => s.trim().replace(/^['"]+|['"]+$/g, ''))
           .filter(Boolean);
         const itemId = step.itemId || '';
         const { epsData, csrfMap } = await page.evaluate(() => {
@@ -384,7 +387,7 @@ async function runSteps(opts, logger = console.log) {
           (step.pathsVar && variables[step.pathsVar]) || step.paths || '';
         const imagePaths = String(rawPaths)
           .split(',')
-          .map(s => s.trim())
+          .map(s => s.trim().replace(/^['"]+|['"]+$/g, ''))
           .filter(Boolean);
         const selector = step.selector || 'input[type="file"]';
         if (typeof page.setInputFiles === 'function') {


### PR DESCRIPTION
## Summary
- sanitize `ebayListingTitle` image paths so quoted values work
- strip quotes from paths in `ebayUploadImage` and `uiUploadFile` steps
- document that quoted paths are handled

## Testing
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_b_6871f4f9ccd483238e4c509f857b0a25