### PR TITLE
Add queue import/export and status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Open [https://localhost:3005](https://localhost:3005) in your browser and build 
 You can also manage stored puppets using the runner page at
 [https://localhost:3005/runner.html](https://localhost:3005/runner.html).
 It allows queuing multiple puppets and passing in custom variables before each run.
+The queue can be exported to or imported from a JSON file and the page shows the
+current state of each job as it runs.
 
 For **click** and **type** steps, provide a CSS selector for the target element.
 Type steps insert each character with a 0.5 s delay to better mimic human input.

--- a/public/runner.html
+++ b/public/runner.html
@@ -32,6 +32,10 @@
   <button onclick="runNow()">Run Now</button>
   <button onclick="addToQueue()">Add To Queue</button>
   <button onclick="startQueue()">Start Queue</button>
+  <button onclick="stopQueue()">Stop Queue</button>
+  <button onclick="exportQueue()">Export Queue</button>
+  <button onclick="document.getElementById('importFile').click()">Import Queue</button>
+  <input type="file" id="importFile" style="display:none" accept="application/json"/>
 </div>
 <h2>Queue</h2>
 <ul id="queueList"></ul>


### PR DESCRIPTION
## Summary
- enhance Runner UI with import/export buttons and stop queue option
- display job state in queue list
- implement client-side logic for queue state handling, cancellation and JSON import/export
- document the new runner features in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6871f97d49e48323bc90ab537aa7dbcb