### PR TITLE
Improve step logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,11 @@ async function runSteps(opts, logger = console.log) {
           step[k] = v;
         }
       }
-      logger(`[ProgramaticPuppet] Executing step ${i + 1}/${steps.length}:`, step);
+      logger(
+        `[ProgramaticPuppet] Executing step ${i + 1}/${steps.length}: ${JSON.stringify(
+          step,
+        )}`,
+      );
       const type = step.type;
       let jumped = false;
       if (type === 'loadURL') {


### PR DESCRIPTION
## Summary
- log step objects to runner queue so you can see full step info

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6872aa74c3e0832382adc67d54b8de09