### PR TITLE
Fix ebay title formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ The **keyPress** step presses the provided keyboard key. Key names are case-inse
 
 The **ebayListingTitle** step sends an image to the GPT‑4o‑mini vision API to
 generate an eBay listing title. Provide the local file path to the image or the
-name of a variable that contains the path. The resulting title is stored in the
-`ebayTitle` variable. When this step is added to a puppet the editor now
+name of a variable that contains the path. The resulting title is cleaned to
+remove any `*` characters and truncated to 80 characters before being stored in
+the `ebayTitle` variable. When this step is added to a puppet the editor now
 automatically creates an `ebayTitle` entry in the Variables panel if one is not
 already present. Set your OpenAI API key in the `OPENAI_API_KEY` environment
 variable before running this step. Paths surrounded by single or double quotes

--- a/index.js
+++ b/index.js
@@ -262,9 +262,10 @@ async function runSteps(opts, logger = console.log) {
               body: JSON.stringify(payload),
             });
             const json = await res.json();
-            const title = json.choices?.[0]?.message?.content?.trim() || '';
-            variables.ebayTitle = title;
-            logger(`[ProgramaticPuppet] ebayTitle: ${title}`);
+            const rawTitle = json.choices?.[0]?.message?.content?.trim() || '';
+            const cleanedTitle = rawTitle.replace(/\*/g, '').slice(0, 80).trim();
+            variables.ebayTitle = cleanedTitle;
+            logger(`[ProgramaticPuppet] ebayTitle: ${cleanedTitle}`);
           } catch (err) {
             logger(`[ProgramaticPuppet] ebayListingTitle error: ${err}`);
           }


### PR DESCRIPTION
## Summary
- clean ebay listing titles by removing `*` and limiting to 80 chars
- document new ebay title behavior in README

## Testing
- `node -c index.js`

------
https://chatgpt.com/codex/tasks/task_b_6872aca9c1888323bff95fce67f2fdf2